### PR TITLE
Use better key for cells

### DIFF
--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -219,8 +219,8 @@ const Grid: React.FC<Props> = (props: Props): React.ReactElement => {
 		<div
 		    key={i}
 		>
-		    {row.map((value) => {
-			const key = v4();
+		    {row.map((value, j) => {
+			const key = (j + 1) + (i * row.length) + "";
 			const Cell = props.cell(value, key);
 			return Cell;
 		    })}


### PR DESCRIPTION
Uses predictable key generation for individual cells. Replaces use of `v4()`.